### PR TITLE
Remove unused modules from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,11 +62,6 @@ request:
 
    from statuscake import ApiClient
    from statuscake.apis import (
-       ContactGroupApu,
-       LocationsApi,
-       MaintenanceWindowsApi,
-       PagespeedApi,
-       SslApi,
        UptimeApi,
    )
 


### PR DESCRIPTION
Some of the modules imported as an example in the README are unused and may confuse the piece as documentation. They have been removed.