### PR TITLE
update python-dateutil for current python versions #18

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-python_dateutil==2.5.3
+python-dateutil==2.9.0
 setuptools==65.3.0
-urllib3==1.25.3
+urllib3==1.26.18
+six==1.16.0

--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,10 @@ VERSION = '1.2.0-beta.1'
 # http://pypi.python.org/pypi/setuptools
 
 REQUIRES = [
-    'urllib3~=1.25.3',
-    'python-dateutil~=2.5.3',
+    'urllib3~=1.26.18',
+    'python-dateutil~=2.9.0',
 ]
+
 
 TESTS_REQUIRE = [
     'pytest~=7.1.3',


### PR DESCRIPTION
Update `python-dateutil` to current version for  #18

Tested locally on python 3.11